### PR TITLE
feat: Add an option `@now-playing-play-keytable` for combinating keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ Values: string
 - `@now-playing-paused-icon`  
 Description: A string to display for `{icon}` component when the music player
 is paused  
-Default: ` ` (empty space)
+Default: ` ` (empty space)  
 Values: string
-
+- @now-playing-play-keytable
+Description: A string that is bound in the key table for combinating keys.  
+Default: `prefix`  
+Values: string
 ### Key Bindings
 
 - `@now-playing-play-pause-key`  

--- a/now-playing.tmux
+++ b/now-playing.tmux
@@ -23,29 +23,31 @@ main() {
   update_tmux_option "status-right"
   update_tmux_option "status-left"
 
+  local keytable="$(get_tmux_option "@now-playing-play-keytable" "prefix")"
+
   local keys="$(get_tmux_option "@now-playing-play-pause-key" ",")"
   local key
   for key in $keys; do
-    tmux unbind "$key"
-    tmux bind-key "$key" run-shell -b "bash $CURRENT_DIR/scripts/music.sh --cmd pause"
+    tmux unbind -T "$keytable" "$key"
+    tmux bind-key -T "$keytable" "$key" run-shell -b "bash $CURRENT_DIR/scripts/music.sh --cmd pause"
   done
 
   keys="$(get_tmux_option "@now-playing-stop-key" ".")"
   for key in $keys; do
-    tmux unbind "$key"
-    tmux bind-key "$key" run-shell -b "bash $CURRENT_DIR/scripts/music.sh --cmd stop"
+    tmux unbind -T "$keytable" "$key"
+    tmux bind-key -T "$keytable" "$key" run-shell -b "bash $CURRENT_DIR/scripts/music.sh --cmd stop"
   done
 
   keys="$(get_tmux_option "@now-playing-previous-key" "\\;")"
   for key in $keys; do
-    tmux unbind "$key"
-    tmux bind-key "$key" run-shell -b "bash $CURRENT_DIR/scripts/music.sh --cmd previous"
+    tmux unbind -T "$keytable" "$key"
+    tmux bind-key -T "$keytable" "$key" run-shell -b "bash $CURRENT_DIR/scripts/music.sh --cmd previous"
   done
 
   keys="$(get_tmux_option "@now-playing-next-key" "'")"
   for key in $keys; do
-    tmux unbind "$key"
-    tmux bind-key "$key" run-shell -b "bash $CURRENT_DIR/scripts/music.sh --cmd next"
+    tmux unbind -T "$keytable" "$key"
+    tmux bind-key -T "$keytable" "$key" run-shell -b "bash $CURRENT_DIR/scripts/music.sh --cmd next"
   done
 }
 


### PR DESCRIPTION
Most of the key bindings have already been used, but this option allows users to define themselves combination keys. 

example: 

```
# Adding command mode 
bind '^b' {
    switch-client -T command-mode
}
set -g @now-playing-play-keytable 'command-mode'

```

Now you can press twice `^b`  to enter command-mode, then press `now-playing` bindings.
