### PR TITLE
Add support for playerctl, allowing tmux-now-playing to support (e.g.) Spotify under Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Showing currently playing track in tmux status bar with music controls
   - iTunes
 - `mpd` ([Music Player Daemon](https://www.musicpd.org)) through `nc` (netcat)
 - [`nowplaying-cli`](https://github.com/kirtan-shah/nowplaying-cli)
+- (Linux) anything that supports MPRIS through `playerctl`
+  - Spotify 
+  - probably can work with other players 
 
 ## Configurations
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Showing currently playing track in tmux status bar with music controls
   - iTunes / Music
 - (Windows through WSL only, experimental) `cscript` (Windows Script Host) - enable the following integrations and more in the future
   - iTunes
+- (Linux) [`playerctl`](https://github.com/altdesktop/playerctl) - services or apps that support the [MPRIS](https://specifications.freedesktop.org/mpris-spec/latest/) specification, such as
+  - Spotify
+  - YouTube Music (under Firefox or Chrome)
+  - VLC
 - `mpd` ([Music Player Daemon](https://www.musicpd.org)) through `nc` (netcat)
 - [Cider](https://cider.sh) through `curl` and `jq`
 - [`nowplaying-cli`](https://github.com/kirtan-shah/nowplaying-cli)
-- (Linux) anything that supports MPRIS through `playerctl`
-  - Spotify 
-  - probably can work with other players 
 
 ## Configurations
 

--- a/players/playerctl.sh
+++ b/players/playerctl.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$(dirname "$CURRENT_DIR")/scripts/cache.sh"
+source "$(dirname "$CURRENT_DIR")/scripts/helpers.sh"
+
+is_running() {
+
+  if (playerctl status | grep "No players found") then 
+    return 1
+  else # Player is found, but not playing (i.e. stopped or paused)
+    return 0
+  fi
+}
+
+is_playing() {
+  if ! is_running; then # Isn't running 
+    return 1
+  fi
+
+  local player_status="$(playerctl status)"
+
+  if test "$player_status" = "Paused"; then
+    return 1
+  fi
+
+  return 0
+}
+
+get_music_data() {
+
+  _playerctl_data() {
+    sh -c "playerctl metadata"
+  }
+
+
+  local status="$(playerctl status)"
+  local title="$(playerctl metadata xesam:artist)"
+  local artist="$(playerctl metadata xesam:title)"
+
+  # MPRIS provides the length in us, then we will need to do a bit of math here.
+   
+  local duration="$(playerctl metadata mpris:length | awk '{printf("%d", int($1/1000000))}')"
+
+  local position="$(playerctl position | cut -d. -f1)"
+
+  #local mpd_state="$(printf "%s" "$mpd_data" | awk '$1 ~ /^state:/ { print $2 }' | cut -d':' -f1)"
+  #local position="$(printf "%s" "$mpd_data" | awk '$1 ~ /^time:/ { print $2 }' | cut -d':' -f1)"
+  #local duration="$(printf "%s" "$mpd_data" | awk '$1 ~ /^time:/ { print $2 }' | cut -d':' -f2)"
+  #local title="$(printf "%s" "$mpd_data" | awk '$1 ~ /^Title:/ { print $0 }' | cut -d':' -f2- | sed 's/^ *//g')"
+  #local artist="$(printf "%s" "$mpd_data" | awk '$1 ~ /^Artist:/ { print $0 }' | cut -d':' -f2- | sed 's/^ *//g')"
+
+  local playerctl_status="$(playerctl status)"
+
+  if test "$playerctl_status" = "Playing"; then
+    status="playing"
+  elif test "$playerctl_status" = "Paused"; then
+    status="paused"
+  fi
+
+  printf "%s\n%s\n%s\n%s\n%s\nSpotify" "$status" "$position" "$duration" "$artist" "$title"
+}
+

--- a/players/playerctl.sh
+++ b/players/playerctl.sh
@@ -6,8 +6,7 @@ source "$(dirname "$CURRENT_DIR")/scripts/cache.sh"
 source "$(dirname "$CURRENT_DIR")/scripts/helpers.sh"
 
 is_running() {
-
-  if (playerctl status | grep "No players found") then 
+  if (playerctl status | grep -q "No players found") then
     return 1
   else # Player is found, but not playing (i.e. stopped or paused)
     return 0
@@ -15,7 +14,7 @@ is_running() {
 }
 
 is_playing() {
-  if ! is_running; then # Isn't running 
+  if ! is_running; then
     return 1
   fi
 
@@ -29,7 +28,6 @@ is_playing() {
 }
 
 get_music_data() {
-
   local status="$(playerctl status ; sleep 1)"
   local title="$(playerctl metadata xesam:artist)"
   local artist="$(playerctl metadata xesam:title)"
@@ -37,9 +35,7 @@ get_music_data() {
   # MPRIS provides the length in us, then we will need to do a bit of math here.
    
   local duration="$(playerctl metadata mpris:length | awk '{printf("%d", int($1/1000000))}')"
-
   local position="$(playerctl position | cut -d. -f1)"
-
   local playerctl_status="$(playerctl status)"
 
   if test "$playerctl_status" = "Playing"; then
@@ -48,7 +44,7 @@ get_music_data() {
     status="paused"
   fi
 
-  printf "%s\n%s\n%s\n%s\n%s\nSpotify" "$status" "$position" "$duration" "$artist" "$title"
+  printf "%s\n%s\n%s\n%s\n%s\nplayerctl" "$status" "$position" "$duration" "$artist" "$title"
 }
 
 send_command() {

--- a/players/playerctl.sh
+++ b/players/playerctl.sh
@@ -30,12 +30,7 @@ is_playing() {
 
 get_music_data() {
 
-  _playerctl_data() {
-    sh -c "playerctl metadata"
-  }
-
-
-  local status="$(playerctl status)"
+  local status="$(playerctl status ; sleep 1)"
   local title="$(playerctl metadata xesam:artist)"
   local artist="$(playerctl metadata xesam:title)"
 
@@ -44,12 +39,6 @@ get_music_data() {
   local duration="$(playerctl metadata mpris:length | awk '{printf("%d", int($1/1000000))}')"
 
   local position="$(playerctl position | cut -d. -f1)"
-
-  #local mpd_state="$(printf "%s" "$mpd_data" | awk '$1 ~ /^state:/ { print $2 }' | cut -d':' -f1)"
-  #local position="$(printf "%s" "$mpd_data" | awk '$1 ~ /^time:/ { print $2 }' | cut -d':' -f1)"
-  #local duration="$(printf "%s" "$mpd_data" | awk '$1 ~ /^time:/ { print $2 }' | cut -d':' -f2)"
-  #local title="$(printf "%s" "$mpd_data" | awk '$1 ~ /^Title:/ { print $0 }' | cut -d':' -f2- | sed 's/^ *//g')"
-  #local artist="$(printf "%s" "$mpd_data" | awk '$1 ~ /^Artist:/ { print $0 }' | cut -d':' -f2- | sed 's/^ *//g')"
 
   local playerctl_status="$(playerctl status)"
 

--- a/players/playerctl.sh
+++ b/players/playerctl.sh
@@ -51,3 +51,12 @@ get_music_data() {
   printf "%s\n%s\n%s\n%s\n%s\nSpotify" "$status" "$position" "$duration" "$artist" "$title"
 }
 
+send_command() {
+  local remote_command="$1"
+
+  if test "$remote_command" = "pause"; then
+    playerctl play-pause
+  else
+    playerctl "$remote_command"
+  fi
+}

--- a/scripts/music.sh
+++ b/scripts/music.sh
@@ -11,6 +11,7 @@ players=(
   "$(dirname "$CURRENT_DIR")/players/mpd.sh"
   "$(dirname "$CURRENT_DIR")/players/applescript.sh"
   "$(dirname "$CURRENT_DIR")/players/cscript.sh"
+  "$(dirname "$CURRENT_DIR")/players/playerctl.sh"
 )
 
 is_playing() {


### PR DESCRIPTION
This pull request adds support for playerctl, allowing players that follow the MPRIS standard (a list is available at https://wiki.archlinux.org/title/MPRIS) to display now-playing in the tmux status bar using your plug-in.

Very hacky, and can be tested more. But seems to work with Spotify at least.