### PR TITLE
Add media-control player support for macOS Tahoe+

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Showing currently playing track in tmux status bar with music controls
   - VLC
 - `mpd` ([Music Player Daemon](https://www.musicpd.org)) through `nc` (netcat)
 - [Cider](https://cider.sh) through `curl` and `jq`
-- [`nowplaying-cli`](https://github.com/kirtan-shah/nowplaying-cli)
+- [`nowplaying-cli`](https://github.com/kirtan-shah/nowplaying-cli) (Note: [not compatible with macOS Tahoe](https://github.com/kirtan-shah/nowplaying-cli/issues/28))
+- [`media-control`](https://github.com/ungive/media-control) - macOS media control CLI tool (recommended for macOS Tahoe and above)
 
 ## Configurations
 
@@ -117,6 +118,11 @@ Values: string (leave empty for no token)
 Description: A boolean string to indicate whether to have Apple's Music app
 processed through nowplaying-cli (which is quite flaky) or not  
 Default: `no`  
+Values: `0` / `no` / `false` / `1` / `yes` / `true`
+- `@now-playing-media-control-include-music-app`  
+Description: A boolean string to indicate whether to have Apple's Music app
+processed through media-control or not  
+Default: `yes`  
 Values: `0` / `no` / `false` / `1` / `yes` / `true`
 
 #### Components

--- a/players/applescript.sh
+++ b/players/applescript.sh
@@ -9,7 +9,14 @@ source "$(dirname "$CURRENT_DIR")/scripts/helpers.sh"
 is_running() {
   # Only macOS with osascript command
   if test "$(uname)" = "Darwin" -a -n "$(command -v osascript)"; then
-    return 0
+    # Check if we're on macOS Tahoe (Darwin 25) or above
+    local darwin_version="$(uname -r | cut -d. -f1)"
+    if test "$darwin_version" -ge 25; then
+      # macOS Tahoe and above - AppleScript currentTrack is broken
+      return 1
+    else
+      return 0
+    fi
   else
     return 1
   fi

--- a/players/media-control.sh
+++ b/players/media-control.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$(dirname "$CURRENT_DIR")/scripts/cache.sh"
+source "$(dirname "$CURRENT_DIR")/scripts/helpers.sh"
+
+INCLUDE_MUSIC="$(get_tmux_option "@now-playing-media-control-include-music-app" "yes")"
+
+include_music() {
+  case "$INCLUDE_MUSIC" in
+    yes|true|1) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_running() {
+  if test -n "$(command -v media-control)"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+is_playing() {
+  if ! is_running; then
+    return 1
+  fi
+
+  local json_data="$(media-control get 2>/dev/null)"
+  if test $? -ne 0 || test -z "$json_data"; then
+    return 1
+  fi
+
+  local playback_rate="$(printf "%s" "$json_data" | jq -r '.playbackRate // 0' 2>/dev/null)"
+  local bundle_id="$(printf "%s" "$json_data" | jq -r '.bundleIdentifier // ""' 2>/dev/null)"
+
+  if test "$playback_rate" = "0" || test "$playback_rate" = "null"; then
+    return 1
+  elif test "$bundle_id" = "com.apple.Music" && ! include_music; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+get_music_data() {
+  local json_data="$(media-control get 2>/dev/null)"
+  
+  if test $? -ne 0 || test -z "$json_data"; then
+    printf "stopped\n0\n0\n\n\nmedia-control"
+    return
+  fi
+
+  local playback_rate="$(printf "%s" "$json_data" | jq -r '.playbackRate // 0' 2>/dev/null)"
+  local position="$(printf "%s" "$json_data" | jq -r '.position // 0' 2>/dev/null | awk '{print int($0)}')"
+  local duration="$(printf "%s" "$json_data" | jq -r '.duration // 0' 2>/dev/null | awk '{print int($0)}')"
+  local title="$(printf "%s" "$json_data" | jq -r '.title // ""' 2>/dev/null)"
+  local artist="$(printf "%s" "$json_data" | jq -r '.artist // ""' 2>/dev/null)"
+
+  local status="playing"
+  if test "$playback_rate" = "0" || test "$playback_rate" = "null"; then
+    status="paused"
+  fi
+
+  printf "%s\n%s\n%s\n%s\n%s\nmedia-control" "$status" "$position" "$duration" "$title" "$artist"
+}
+
+send_command() {
+  local remote_command="$1"
+  case "$remote_command" in
+    "pause"|"playpause")
+      media-control toggle-play-pause
+      ;;
+    "stop")
+      media-control pause
+      ;;
+    "previous")
+      media-control previous-track
+      ;;
+    "next")
+      media-control next-track
+      ;;
+    *)
+      # Default to toggle play/pause for unknown commands
+      media-control toggle-play-pause
+      ;;
+  esac
+}

--- a/scripts/music.sh
+++ b/scripts/music.sh
@@ -9,6 +9,7 @@ source "$CURRENT_DIR/shada.sh"
 players=(
   "$(dirname "$CURRENT_DIR")/players/nowplaying-cli.sh"
   "$(dirname "$CURRENT_DIR")/players/cider.sh"
+  "$(dirname "$CURRENT_DIR")/players/media-control.sh"
   "$(dirname "$CURRENT_DIR")/players/mpd.sh"
   "$(dirname "$CURRENT_DIR")/players/applescript.sh"
   "$(dirname "$CURRENT_DIR")/players/cscript.sh"


### PR DESCRIPTION
# Changes
- feat(media-control): add new player script supporting media-control CLI for macOS Tahoe and above
- feat(applescript): update is_running to disable AppleScript for macOS Darwin 25+ due to broken currentTrack
- feat(scripts): include media-control player in music player list
- docs(README): add media-control to player list and document config option for Music app inclusion


# Testing
Recorded asciinema showing it works.

[![asciicast](https://asciinema.org/a/0y7ffvRORznCwlFWv01BCBMJO.svg)](https://asciinema.org/a/0y7ffvRORznCwlFWv01BCBMJO)
Fixes https://github.com/spywhere/tmux-now-playing/issues/13